### PR TITLE
Prevent variables from entering global scope

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -274,7 +274,7 @@ Lynx.prototype.count = function count(stats, delta, sample_rate) {
   //
   // Batch up all these stats to send
   //
-  batch = {};
+  var batch = {};
   for(var i in stats) {
     batch[stats[i]] = delta + '|c';
   }
@@ -569,7 +569,7 @@ Lynx.sample = function sample(stats, sample_rate) {
     //       should be at the individual stat level
     //
     Object.keys(stats).forEach(function construct_sampled(stat) {
-      value = stats[stat];
+      var value = stats[stat];
       sampled_stats[stat] = value + '|@' + sample_rate;
     });
   }


### PR DESCRIPTION
Two variables are declared without 'var'.
