### PR TITLE
Fixes cancelTimeout error (by using clearTimeout).

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -475,7 +475,7 @@ Lynx.prototype.close = function close() {
   // Timer
   //
   if (this.last_used_timer) {
-    cancelTimeout(this.last_used_timer);
+    clearTimeout(this.last_used_timer);
     this.last_used_timer = undefined;
   }
 };


### PR DESCRIPTION
I receive this error message -- `ReferenceError: cancelTimeout is not defined`.  I see that `clearTimeout` is used elsewhere.

Sorry about the whitespace change at the end of the file.  I used Github's web editor and it made the change automatically.
