### PR TITLE
Avoid corrupt UDP packages due to being to large

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -364,7 +364,7 @@ Lynx.prototype.send = function send(stats, sample_rate) {
     //
     // Data to be sent
     //
-    , send_data
+    , send_data     = []
     ;
 
   //
@@ -385,18 +385,39 @@ Lynx.prototype.send = function send(stats, sample_rate) {
   //
   // Construct our send request
   // If we have multiple stats send them in the same udp package
+  // Don't send more than 5 per package to avoid UDP package size limitations.
   // This is achieved by having newline separated stats.
   //
-  send_data = all_stats.map(function construct_stat(stat) {
-    return self.scope + stat + ':' + sampled_stats[stat];
-  }).join('\n');
+  var stat_number = 0
+    , package_number = 0
+    , stats_in_package = 0
+    ;
+  for ( ; stat_number < all_stats.length; stat_number++) {
+    if (stats_in_package > 0) {
+      send_data[package_number] = [
+        send_data[package_number]
+      , self.scope + all_stats[stat_number] + ':' + sampled_stats[all_stats[stat_number]]
+      ].join('\n');
+    } else {
+      send_data.push(self.scope + all_stats[stat_number] + ':' + sampled_stats[all_stats[stat_number]]);
+    }
+
+    stats_in_package++;
+    if (stats_in_package === 5) {
+      package_number++;
+      stats_in_package = 0;
+    }
+  }
 
   //
   // Encode our data to a buffer
   //
-  var buffer = new Buffer(send_data, 'utf8')
+  var buffers = []
     , socket
     ;
+  send_data.map(function stats_to_buffers (stat) {
+    buffers.push(new Buffer(stat, 'utf8'));
+  });
 
   //
   // Do we already have a socket object we can use?
@@ -441,8 +462,10 @@ Lynx.prototype.send = function send(stats, sample_rate) {
   //
   // Send the data
   //
-  this.emit('data', buffer);
-  socket.send(buffer, 0, buffer.length, this.port, this.host, noop);
+  for (var i = 0; i < buffers.length; i++) {
+    this.emit('data', buffers[i]);
+    socket.send(buffers[i], 0, buffers[i].length, this.port, this.host, noop);
+  }
 };
 
 //


### PR DESCRIPTION
We experience an issue with incomplete data being sent through lynx, because of bulks of several hundreds of metrics at a time are being sent with the `send()` function. The incomplete data is because of the UDP package size being to large for all systems to handle, and thus being truncated on the way from lynx to StatsD.
This patch will put every 5 metrics in its own UDP package which should work for basically all metrics.

I have tried to write the code in the same format as the existing code, but let me know if there are any changes you would like me to make.
