### PR TITLE
Use process.hrtime for high resolution timing, when available

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -135,7 +135,13 @@ Lynx.prototype.createTimer = function createTimer(stat, sample_rate) {
   var self       = this
     , start_time = new Date ().getTime()
     , stopped    = false
+    , duration
+    , start_hrtime
     ;
+
+  if (typeof process.hrtime === "function") {
+    var start_hrtime = process.hrtime();
+  }
 
   //
   // ### function stop()
@@ -158,7 +164,15 @@ Lynx.prototype.createTimer = function createTimer(stat, sample_rate) {
     //
     // Calculate duration
     //
-    var duration = new Date ().getTime() - start_time;
+    if (start_hrtime) {
+      var stop_hrtime = process.hrtime()
+        , seconds     = stop_hrtime[0] - start_hrtime[0]
+        , nanos       = stop_hrtime[1] - start_hrtime[1]
+        ;
+      duration = seconds * 1000 + nanos / 1000000
+    } else {
+      duration = new Date ().getTime() - start_time;
+    }
 
     //
     // Emit


### PR DESCRIPTION
`process.hrtime` exists on node for exactly the purpose of high-resolution timing information. Maybe we could use that?
