### PR TITLE
make `new` optional.

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -36,6 +36,10 @@ var EPHEMERAL_LIFETIME_MS = 1000;
 // Returns a new `Lynx` client
 //
 function Lynx(host, port, options) {
+  if (!(this instanceof Lynx)) {
+    return new Lynx(host, port, options);
+  }
+  
   var self = this;
 
   //


### PR DESCRIPTION
<marquee> /o/ \o\ /o/ </marquee>

I added a thing to the constructor so it just "does the right thing" if you

``` js
var lynx = require("lynx")

var statsd = lynx(host, port)
```
