### PR TITLE
Emit real errors

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -629,7 +629,7 @@ Lynx.prototype._update_last_used = function _update_last_used() {
 // custom stuff with errors
 //
 Lynx.prototype._default_error_handler = function _default_error_handler(e) {
-  console.log(e.message);
+  this.emit('error', e);
 };
 
 //


### PR DESCRIPTION
This makes lynx silent by default.

It also makes lynx use the standard node error system by emitting them on the event emitter.
