### PR TITLE
create real errors

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -11,6 +11,13 @@ var dgram    = require('dgram')
   , noop     = function noop() {}
   ;
 
+function makeError(opts) {
+  var error = new Error(opts.message);
+  error.f = opts.f;
+  error.args = opts.args;
+  return error;
+}
+
 //
 // Max idle time for a ephemeral socket
 //
@@ -149,9 +156,9 @@ Lynx.prototype.createTimer = function createTimer(stat, sample_rate) {
     //
     if(stopped) {
       self.on_error(
-        { message : "Can't stop a timer twice"
+        makeError({ message : "Can't stop a timer twice"
         , f       : 'stop'
-        });
+        }));
       return;
     }
 
@@ -249,10 +256,10 @@ Lynx.prototype.count = function count(stats, delta, sample_rate) {
     // Error: Can't set if its not even an array by now
     //
     this.on_error(
-      { message : "Can't set if its not even an array by now"
+      makeError({ message : "Can't set if its not even an array by now"
       , f       : 'count'
       , args    : arguments
-      });
+      }));
     return;
   }
 
@@ -264,10 +271,10 @@ Lynx.prototype.count = function count(stats, delta, sample_rate) {
     // Error: Must be either a number or a string, we cant send other stuff
     //
     this.on_error(
-      { message : 'Must be either a number or a string'
+      makeError({ message : 'Must be either a number or a string'
       , f       : 'count'
       , args    : arguments
-      });
+      }));
     return;
   }
 
@@ -375,10 +382,10 @@ Lynx.prototype.send = function send(stats, sample_rate) {
     // Error: Nothing to send
     //
     this.on_error(
-      { message : 'Nothing to send'
+      makeError({ message : 'Nothing to send'
       , f       : 'send'
       , args    : arguments
-      });
+      }));
     return;
   }
 


### PR DESCRIPTION
The errors passed to on_error should not be object literals
  they should be real errors with real stack traces.
