### PR TITLE
support options object

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -48,12 +48,17 @@ function Lynx(host, port, options) {
   }
   
   var self = this;
+  
+  if (typeof host === 'object') {
+    options = host;
+    host = null;
+  }
 
   //
   // Server hostname and port
   //
-  this.host = host || '127.0.0.1';
-  this.port = port || 8125;
+  this.host = (options && options.host) || host || '127.0.0.1';
+  this.port = (options && options.port) || port || 8125;
 
   //
   // Optional shared socket


### PR DESCRIPTION
This allows the usage pattern of

``` js
var statsd = Lynx({
  host: 'localhost',
  port: 9092
})
```

Having a single options object instead of two positional arguments and an options object is easier.
