### PR TITLE
Update README info about timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ setTimeout(function () {
 }, 100);
 ```
 
-Timers use `Date.getTime()` which is known for being imprecise at the ms level. If this is a problem to you please submit a pull request and I'll take it.
+Timers use `process.hrtime()` if available, and fallback to `Date.getTime()` which is known for being imprecise at the ms level.
 
 ### Batching
 


### PR DESCRIPTION
I saw the comment about timers depending on `Date.getTime()` and was planning a PR to use `process.hrtime`, but found it was already done :) This PR updates the README to reflect that.
