### PR TITLE
Fix incorrect loop through array

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -275,7 +275,7 @@ Lynx.prototype.count = function count(stats, delta, sample_rate) {
   // Batch up all these stats to send
   //
   var batch = {};
-  for(var i in stats) {
+  for(var i = 0; i < stats.length; i++) {
     batch[stats[i]] = delta + '|c';
   }
 


### PR DESCRIPTION
I think we should be looping through the elements of the array, not its properties.
