### PR TITLE
Loop on properties instead of in everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ node_js:
   - 0.8
   - 0.9
   - 0.10
+before_install:
+  - 'npm install npm -g'

--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -301,7 +301,9 @@ Lynx.prototype.count = function count(stats, delta, sample_rate) {
   //
   var batch = {};
   for(var i in stats) {
-    batch[stats[i]] = delta + '|c';
+    if (stats.hasOwnProperty(i)) {
+      batch[stats[i]] = delta + '|c';
+    }
   }
 
   //


### PR DESCRIPTION
Some people extend the native prototypes and that breaks the batch sending of stats.
