### PR TITLE
Now the timer.stop method will return the duration time

### DIFF
--- a/lib/lynx.js
+++ b/lib/lynx.js
@@ -194,6 +194,8 @@ Lynx.prototype.createTimer = function createTimer(stat, sample_rate) {
     // So no one stops a timer twice (causing two emits)
     //
     stopped = true;
+
+    return duration;
   }
 
   //


### PR DESCRIPTION
With this change it will be easier to know how much the process took, in case you want additional logs of the timer.